### PR TITLE
Remove IMPORT from startup_M2351.s that is not required

### DIFF
--- a/Library/Device/Nuvoton/M2351/Source/ARM/startup_M2351.s
+++ b/Library/Device/Nuvoton/M2351/Source/ARM/startup_M2351.s
@@ -51,7 +51,6 @@ __heap_limit
                 EXPORT  __Vectors
                 EXPORT  __Vectors_End
                 EXPORT  __Vectors_Size
-				IMPORT  SendChar_ToUART
 
 __Vectors       DCD     __initial_sp               ;     Top of Stack
                 DCD     Reset_Handler              ;     Reset Handler


### PR DESCRIPTION
This IMPORT in startup_M2351.s is not required, and causes trouble when trying to compile with custom semihosting code.